### PR TITLE
Fix failing build

### DIFF
--- a/test/static_exception_test.cpp
+++ b/test/static_exception_test.cpp
@@ -19,6 +19,7 @@
 #include <malloc.h>
 #include <dlfcn.h>
 #include <gtest/gtest.h>
+#include <iomanip>
 
 
 #include "SomeClass.hpp"


### PR DESCRIPTION
When trying to build the repo with g++ 14.2.1, `make` fails with `error: ‘setprecision’ is not a member of ‘std’`.
This is fixed by including iomanip